### PR TITLE
Include work location code in location information

### DIFF
--- a/ibmBluePages.js
+++ b/ibmBluePages.js
@@ -88,6 +88,7 @@ async function getUserLocationByW3ID(W3ID) {
 		buildingName: getAttrValue('buildingname', xml),
 		country: getAttrValue('co', xml),
 		countryAlphaCode: getAttrValue('c', xml),
+		workLocation: getAttrValue('workloc', xml),
 		employeeCountryCode: getAttrValue('employeecountrycode', xml)
 	};
 }

--- a/tests/ibmBluepages.test.js
+++ b/tests/ibmBluepages.test.js
@@ -10,6 +10,16 @@ test('the result is an object containing users information', async () => {
 	return expect(data).toBeDefined();
 });
 
+test('the result is an object containing users location', async () => {
+  const data = await bluePages.getUserLocationByW3ID('aromeroh@cr.ibm.com');
+  return expect(data).toBeDefined();
+});
+
+test('the result is an object containing users location including the office', async () => {
+  const data = await bluePages.getUserLocationByW3ID('aromeroh@cr.ibm.com');
+  return expect(data).toHaveProperty('workLocation');
+});
+
 test('the result is the primary username of the user', async () => {
 	const data = await bluePages.getPrimaryUserNameByW3ID('aromeroh@cr.ibm.com');
 	return expect(data).toBe('aromeroh');


### PR DESCRIPTION
It's useful to have the work location code in the location information. This is, for example, the input to the internal reso systems which can be used to find an employee's work address or geo coordinates.